### PR TITLE
fix(gen): handle error from MarkFlagRequired("input") via cobra.CheckErr

### DIFF
--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -39,7 +39,7 @@ func New() *cobra.Command {
 	cmd.Flags().BoolVarP(&typed, "typed", "t", true, "Generated Typed API")
 	cmd.Flags().StringVarP(&output, "output", "o", defaultOutPath, "Directory to place generated code")
 	cmd.Flags().StringVarP(&input, "input", "i", "", "Path to Go interface file with raw SQL annotations")
-	cmd.MarkFlagRequired("input")
+	cobra.CheckErr(cmd.MarkFlagRequired("input"))
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ X] Do only one thing
- [ X] Non breaking API changes
- [ X] Tested

### What did this pull request do?

Handle the previously unhandled error from the Cobra required flag setup. Wrap `cmd.MarkFlagRequired("input")` with `cobra.CheckErr(...)` in `internal/gen/gen.go` so setup failures print usage and exit non‑zero.

### User Case Description

ensuring misconfiguration is caught.
<!-- Summary by @propel-code-bot -->

---

**Handle `MarkFlagRequired("input")` Error with `cobra.CheckErr`**

Replaces the direct call to `cmd.MarkFlagRequired("input")` with `cobra.CheckErr(cmd.MarkFlagRequired("input"))` in `internal/gen/gen.go`. This ensures any failure during flag-setup is surfaced to users and the CLI exits with a non-zero status.

<details>
<summary><strong>Key Changes</strong></summary>

• Wrapped `cmd.MarkFlagRequired("input")` with `cobra.CheckErr(...)`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `internal/gen/gen.go` (CLI flag initialization for the `gen` command)

</details>

---
*This summary was automatically generated by @propel-code-bot*