### PR TITLE
Fix code generator: support generic type parameters and import aliasing

### DIFF
--- a/examples/models/enum/enum.go
+++ b/examples/models/enum/enum.go
@@ -1,0 +1,3 @@
+package enum
+
+type Enum string

--- a/examples/models/enum/enum/enum.go
+++ b/examples/models/enum/enum/enum.go
@@ -1,0 +1,3 @@
+package enum
+
+type Enum string

--- a/examples/models/user.go
+++ b/examples/models/user.go
@@ -38,7 +38,10 @@ type User struct {
 	IsAdult    bool   `gorm:"column:is_adult"`
 	Profile    string `gen:"json"`
 	AwardTypes datatypes.JSONSlice[int]
+	TagTypes   datatypes.JSONSlice[UserTagType]
 }
+
+type UserTagType string
 
 type Account struct {
 	gorm.Model

--- a/examples/models/user.go
+++ b/examples/models/user.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"time"
 
+	"gorm.io/cli/gorm/examples/models/enum"
+	enum2 "gorm.io/cli/gorm/examples/models/enum/enum"
 	"gorm.io/cli/gorm/genconfig"
 	"gorm.io/datatypes"
-	datatypes2 "gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -39,8 +40,10 @@ type User struct {
 	IsAdult    bool   `gorm:"column:is_adult"`
 	Profile    string `gen:"json"`
 	AwardTypes datatypes.JSONSlice[int]
-	TagTypes   datatypes2.JSONSlice[UserTagType]
+	TagTypes   datatypes.JSONSlice[UserTagType]
 	Tag        UserTagType
+	Enum       enum.Enum
+	Enum2      enum2.Enum
 }
 
 type UserTagType string

--- a/examples/models/user.go
+++ b/examples/models/user.go
@@ -39,6 +39,7 @@ type User struct {
 	Profile    string `gen:"json"`
 	AwardTypes datatypes.JSONSlice[int]
 	TagTypes   datatypes.JSONSlice[UserTagType]
+	Tag        UserTagType
 }
 
 type UserTagType string

--- a/examples/models/user.go
+++ b/examples/models/user.go
@@ -6,6 +6,7 @@ import (
 
 	"gorm.io/cli/gorm/genconfig"
 	"gorm.io/datatypes"
+	datatypes2 "gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -38,7 +39,7 @@ type User struct {
 	IsAdult    bool   `gorm:"column:is_adult"`
 	Profile    string `gen:"json"`
 	AwardTypes datatypes.JSONSlice[int]
-	TagTypes   datatypes.JSONSlice[UserTagType]
+	TagTypes   datatypes2.JSONSlice[UserTagType]
 	Tag        UserTagType
 }
 

--- a/examples/output/models/user.go
+++ b/examples/output/models/user.go
@@ -5,7 +5,6 @@ package models
 import (
 	"database/sql"
 
-	"gorm.io/cli/gorm/examples"
 	"gorm.io/cli/gorm/examples/models"
 	"gorm.io/cli/gorm/field"
 	"gorm.io/datatypes"
@@ -21,7 +20,7 @@ var User = struct {
 	Age        field.Number[int]
 	Birthday   field.Time
 	Score      field.Field[sql.NullInt64]
-	LastLogin  field.Time
+	LastLogin  field.Field[sql.NullTime]
 	Account    field.Struct[models.Account]
 	Pets       field.Slice[models.Pet]
 	Toys       field.Slice[models.Toy]
@@ -34,8 +33,9 @@ var User = struct {
 	Friends    field.Slice[models.User]
 	Role       field.String
 	IsAdult    field.Bool
-	Profile    examples.JSON
+	Profile    field.String
 	AwardTypes field.Struct[datatypes.JSONSlice[int]]
+	TagTypes   field.Struct[datatypes.JSONSlice[models.UserTagType]]
 }{
 	ID:         field.Number[uint]{}.WithColumn("id"),
 	CreatedAt:  field.Time{}.WithColumn("created_at"),
@@ -45,7 +45,7 @@ var User = struct {
 	Age:        field.Number[int]{}.WithColumn("age"),
 	Birthday:   field.Time{}.WithColumn("birthday"),
 	Score:      field.Field[sql.NullInt64]{}.WithColumn("score"),
-	LastLogin:  field.Time{}.WithColumn("last_login"),
+	LastLogin:  field.Field[sql.NullTime]{}.WithColumn("last_login"),
 	Account:    field.Struct[models.Account]{}.WithName("Account"),
 	Pets:       field.Slice[models.Pet]{}.WithName("Pets"),
 	Toys:       field.Slice[models.Toy]{}.WithName("Toys"),
@@ -58,8 +58,9 @@ var User = struct {
 	Friends:    field.Slice[models.User]{}.WithName("Friends"),
 	Role:       field.String{}.WithColumn("role"),
 	IsAdult:    field.Bool{}.WithColumn("is_adult"),
-	Profile:    examples.JSON{}.WithColumn("profile"),
+	Profile:    field.String{}.WithColumn("profile"),
 	AwardTypes: field.Struct[datatypes.JSONSlice[int]]{}.WithName("AwardTypes"),
+	TagTypes:   field.Struct[datatypes.JSONSlice[models.UserTagType]]{}.WithName("TagTypes"),
 }
 
 var Account = struct {
@@ -70,7 +71,7 @@ var Account = struct {
 	UserID       field.Field[sql.NullInt64]
 	Number       field.String
 	RewardPoints field.Field[sql.NullInt64]
-	LastUsedAt   field.Time
+	LastUsedAt   field.Field[sql.NullTime]
 }{
 	ID:           field.Number[uint]{}.WithColumn("id"),
 	CreatedAt:    field.Time{}.WithColumn("created_at"),
@@ -79,7 +80,7 @@ var Account = struct {
 	UserID:       field.Field[sql.NullInt64]{}.WithColumn("user_id"),
 	Number:       field.String{}.WithColumn("number"),
 	RewardPoints: field.Field[sql.NullInt64]{}.WithColumn("reward_points"),
-	LastUsedAt:   field.Time{}.WithColumn("last_used_at"),
+	LastUsedAt:   field.Field[sql.NullTime]{}.WithColumn("last_used_at"),
 }
 
 var Pet = struct {

--- a/examples/output/models/user.go
+++ b/examples/output/models/user.go
@@ -36,8 +36,8 @@ var User = struct {
 	IsAdult    field.Bool
 	Profile    examples.JSON
 	AwardTypes field.Struct[datatypes.JSONSlice[int]]
-	Tag        field.Field[models.UserTagType]
 	TagTypes   field.Struct[datatypes.JSONSlice[models.UserTagType]]
+	Tag        field.Field[models.UserTagType]
 }{
 	ID:         field.Number[uint]{}.WithColumn("id"),
 	CreatedAt:  field.Time{}.WithColumn("created_at"),
@@ -62,8 +62,8 @@ var User = struct {
 	IsAdult:    field.Bool{}.WithColumn("is_adult"),
 	Profile:    examples.JSON{}.WithColumn("profile"),
 	AwardTypes: field.Struct[datatypes.JSONSlice[int]]{}.WithName("AwardTypes"),
-	Tag:        field.Field[models.UserTagType]{}.WithColumn("tag"),
 	TagTypes:   field.Struct[datatypes.JSONSlice[models.UserTagType]]{}.WithName("TagTypes"),
+	Tag:        field.Field[models.UserTagType]{}.WithColumn("tag"),
 }
 
 var Account = struct {

--- a/examples/output/models/user.go
+++ b/examples/output/models/user.go
@@ -36,6 +36,7 @@ var User = struct {
 	IsAdult    field.Bool
 	Profile    examples.JSON
 	AwardTypes field.Struct[datatypes.JSONSlice[int]]
+	Tag        field.Field[models.UserTagType]
 	TagTypes   field.Struct[datatypes.JSONSlice[models.UserTagType]]
 }{
 	ID:         field.Number[uint]{}.WithColumn("id"),
@@ -61,6 +62,7 @@ var User = struct {
 	IsAdult:    field.Bool{}.WithColumn("is_adult"),
 	Profile:    examples.JSON{}.WithColumn("profile"),
 	AwardTypes: field.Struct[datatypes.JSONSlice[int]]{}.WithName("AwardTypes"),
+	Tag:        field.Field[models.UserTagType]{}.WithColumn("tag"),
 	TagTypes:   field.Struct[datatypes.JSONSlice[models.UserTagType]]{}.WithName("TagTypes"),
 }
 

--- a/examples/output/models/user.go
+++ b/examples/output/models/user.go
@@ -5,6 +5,7 @@ package models
 import (
 	"database/sql"
 
+	"gorm.io/cli/gorm/examples"
 	"gorm.io/cli/gorm/examples/models"
 	"gorm.io/cli/gorm/field"
 	"gorm.io/datatypes"
@@ -20,7 +21,7 @@ var User = struct {
 	Age        field.Number[int]
 	Birthday   field.Time
 	Score      field.Field[sql.NullInt64]
-	LastLogin  field.Field[sql.NullTime]
+	LastLogin  field.Time
 	Account    field.Struct[models.Account]
 	Pets       field.Slice[models.Pet]
 	Toys       field.Slice[models.Toy]
@@ -33,7 +34,7 @@ var User = struct {
 	Friends    field.Slice[models.User]
 	Role       field.String
 	IsAdult    field.Bool
-	Profile    field.String
+	Profile    examples.JSON
 	AwardTypes field.Struct[datatypes.JSONSlice[int]]
 	TagTypes   field.Struct[datatypes.JSONSlice[models.UserTagType]]
 }{
@@ -45,7 +46,7 @@ var User = struct {
 	Age:        field.Number[int]{}.WithColumn("age"),
 	Birthday:   field.Time{}.WithColumn("birthday"),
 	Score:      field.Field[sql.NullInt64]{}.WithColumn("score"),
-	LastLogin:  field.Field[sql.NullTime]{}.WithColumn("last_login"),
+	LastLogin:  field.Time{}.WithColumn("last_login"),
 	Account:    field.Struct[models.Account]{}.WithName("Account"),
 	Pets:       field.Slice[models.Pet]{}.WithName("Pets"),
 	Toys:       field.Slice[models.Toy]{}.WithName("Toys"),
@@ -58,7 +59,7 @@ var User = struct {
 	Friends:    field.Slice[models.User]{}.WithName("Friends"),
 	Role:       field.String{}.WithColumn("role"),
 	IsAdult:    field.Bool{}.WithColumn("is_adult"),
-	Profile:    field.String{}.WithColumn("profile"),
+	Profile:    examples.JSON{}.WithColumn("profile"),
 	AwardTypes: field.Struct[datatypes.JSONSlice[int]]{}.WithName("AwardTypes"),
 	TagTypes:   field.Struct[datatypes.JSONSlice[models.UserTagType]]{}.WithName("TagTypes"),
 }
@@ -71,7 +72,7 @@ var Account = struct {
 	UserID       field.Field[sql.NullInt64]
 	Number       field.String
 	RewardPoints field.Field[sql.NullInt64]
-	LastUsedAt   field.Field[sql.NullTime]
+	LastUsedAt   field.Time
 }{
 	ID:           field.Number[uint]{}.WithColumn("id"),
 	CreatedAt:    field.Time{}.WithColumn("created_at"),
@@ -80,7 +81,7 @@ var Account = struct {
 	UserID:       field.Field[sql.NullInt64]{}.WithColumn("user_id"),
 	Number:       field.String{}.WithColumn("number"),
 	RewardPoints: field.Field[sql.NullInt64]{}.WithColumn("reward_points"),
-	LastUsedAt:   field.Field[sql.NullTime]{}.WithColumn("last_used_at"),
+	LastUsedAt:   field.Time{}.WithColumn("last_used_at"),
 }
 
 var Pet = struct {

--- a/internal/gen/generator.go
+++ b/internal/gen/generator.go
@@ -466,7 +466,7 @@ func (f Field) Type() string {
 	}
 
 	if typ := loadNamedType(f.file.goModDir, f.file.getFullImportPath(pkgName), typName); typ != nil {
-		if ImplementsAllowedInterfaces(typ) {
+		if ImplementsAllowedInterfaces(typ) || IsUnderlyingComparable(typ) {
 			return fmt.Sprintf("field.Field[%s]", filepath.Base(goType))
 		}
 	}

--- a/internal/gen/generator_test.go
+++ b/internal/gen/generator_test.go
@@ -180,6 +180,7 @@ func TestProcessStructType(t *testing.T) {
 			{Name: "Profile", DBName: "profile", GoType: "string", NamedGoType: "json"},
 			{Name: "AwardTypes", DBName: "award_types", GoType: "datatypes.JSONSlice[int]"},
 			{Name: "TagTypes", DBName: "tag_types", GoType: "datatypes.JSONSlice[UserTagType]"},
+			{Name: "Tag", DBName: "tag", GoType: "UserTagType"},
 		},
 	}
 

--- a/internal/gen/generator_test.go
+++ b/internal/gen/generator_test.go
@@ -181,6 +181,8 @@ func TestProcessStructType(t *testing.T) {
 			{Name: "AwardTypes", DBName: "award_types", GoType: "datatypes.JSONSlice[int]"},
 			{Name: "TagTypes", DBName: "tag_types", GoType: "datatypes.JSONSlice[UserTagType]"},
 			{Name: "Tag", DBName: "tag", GoType: "UserTagType"},
+			{Name: "Enum", DBName: "enum", GoType: "enum.Enum"}, // 添加
+			{Name: "Enum2", DBName: "enum2", GoType: "enum2.Enum"},
 		},
 	}
 

--- a/internal/gen/generator_test.go
+++ b/internal/gen/generator_test.go
@@ -179,6 +179,7 @@ func TestProcessStructType(t *testing.T) {
 			{Name: "IsAdult", DBName: "is_adult", GoType: "bool"},
 			{Name: "Profile", DBName: "profile", GoType: "string", NamedGoType: "json"},
 			{Name: "AwardTypes", DBName: "award_types", GoType: "datatypes.JSONSlice[int]"},
+			{Name: "TagTypes", DBName: "tag_types", GoType: "datatypes.JSONSlice[UserTagType]"},
 		},
 	}
 

--- a/internal/gen/utils.go
+++ b/internal/gen/utils.go
@@ -210,3 +210,27 @@ func stripGeneric(s string) string {
 	}
 	return s
 }
+
+// splitGenericArgs splits a generic type argument string into individual arguments.
+func splitGenericArgs(s string) []string {
+	var args []string
+	depth := 0
+	start := 0
+	for i, char := range s {
+		switch char {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				args = append(args, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	if start < len(s) {
+		args = append(args, s[start:])
+	}
+	return args
+}

--- a/internal/gen/utils.go
+++ b/internal/gen/utils.go
@@ -73,6 +73,14 @@ func ImplementsAllowedInterfaces(typ types.Type) bool {
 	return false
 }
 
+func IsUnderlyingComparable(typ types.Type) bool {
+	underlying := typ.Underlying()
+	if _, ok := underlying.(*types.Struct); ok {
+		return false
+	}
+	return types.Comparable(underlying)
+}
+
 func findGoModDir(filename string) string {
 	cmd := exec.Command("go", "env", "GOMOD")
 	cmd.Dir = filepath.Dir(filename)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
generics types with custom type support

### User Case Description


When using generic types from external packages with custom model types as type parameters (e.g., `datatypes.JSONSlice[UserTagType]` where `UserTagType` is a custom type), the generator would:

1. Incorrectly parse package and type names by treating dots inside generic brackets as package separators
2. Generate invalid Go code with full package paths in generic parameters instead of using short package names with proper imports

**Example:**
```go
type User struct {
    TagTypes datatypes.JSONSlice[UserTagType] `gorm:"column:tag_types"`
}

TagTypes   field.Struct[datatypes.JSONSlice[models.UserTagType]]
<!-- Summary by @propel-code-bot -->

---

**Generator now properly parses & imports generic types with custom parameters**

This PR refactors the GORM CLI code-generator so it can recognise and rewrite generic type expressions that include custom / external model types (e.g., `datatypes.JSONSlice[models.UserTagType]`). The update prevents erroneous package-path retention inside brackets, adds missing imports, and treats comparable custom enums as scalars. Examples, golden output and unit-tests are expanded to cover the new behaviour.

<details>
<summary><strong>Key Changes</strong></summary>

• Re-worked `Field.Type()` to locate the last `.` before a `[` token and call new helper `processGenericType()` for generic-aware rewriting
• Introduced `Field.processGenericType()`, `File.getImportAliasType()`, `File.getImport()` and `utils.splitGenericArgs()` to recursively normalise package paths and register imports for nested generic arguments
• Added `IsUnderlyingComparable()` in `internal/gen/utils.go` and integrated it in `Field.Type()` allowing custom enum types (non-struct comparables) to map to `field.Field`
• Updated example model `examples/models/user.go`, golden file `examples/output/models/user.go`, and unit test `internal/gen/generator_test.go` with fields that exercise the new generic parsing logic
• Added two stub enum packages under `examples/models/enum` for test coverage

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `internal/gen/generator.go`
• `internal/gen/utils.go`
• code-gen examples & golden output
• unit tests

</details>

---
*This summary was automatically generated by @propel-code-bot*