### PR TITLE
test: Add unit tests for internal/gen command flags

### DIFF
--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -1,0 +1,61 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestNewCommandFlags verifies the command returned by New has the expected flags
+// and that running it without the required input flag returns an error.
+func TestNewCommandFlags(t *testing.T) {
+	cmd := New()
+	if cmd == nil {
+		t.Fatal("New() returned nil command")
+	}
+
+	// Ensure flags exist
+	if cmd.Flags().Lookup("typed") == nil {
+		t.Fatalf("expected 'typed' flag to be present")
+	}
+	if cmd.Flags().Lookup("output") == nil {
+		t.Fatalf("expected 'output' flag to be present")
+	}
+	if cmd.Flags().Lookup("input") == nil {
+		t.Fatalf("expected 'input' flag to be present")
+	}
+
+	// Save original RunE and restore later.
+	origRunE := cmd.RunE
+	defer func() { cmd.RunE = origRunE }()
+
+	// Replace RunE with a no-op to avoid side effects from file operations.
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+
+	// Execute without setting input flag - cobra will check required flags during ParseFlags
+	// Use cobra's Flag error handling by calling PreRunE if present then ExecuteC.
+	_, err := cmd.ExecuteC()
+	if err == nil {
+		t.Fatalf("expected error when executing command without required 'input' flag")
+	}
+
+	// Now set the required flag and ensure no flag parsing error occurs.
+	cmd.SetArgs([]string{"--input", "dummy.go"})
+	_, err = cmd.ExecuteC()
+	if err != nil {
+		t.Fatalf("unexpected error executing command with input set: %v", err)
+	}
+}
+
+// TestMarkFlagRequiredBehavior ensures cobra.MarkFlagRequired behaves as expected
+func TestMarkFlagRequiredBehavior(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	cmd.Flags().String("input", "", "input file")
+	// MarkFlagRequired returns an error when flag not found; here it should not.
+	err := cmd.MarkFlagRequired("input")
+	if err != nil {
+		t.Fatalf("expected no error from MarkFlagRequired, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

adds unit tests for `internal/gen` to verify flags and required-flag behavior
<!-- Summary by @propel-code-bot -->

---

**Add unit tests for flag handling in `internal/gen` command**

Adds a single test file that exercises the `New()` command in `internal/gen`, ensuring all expected flags (`typed`, `output`, `input`) are present and that the `input` flag is marked as required. Additional coverage verifies `cobra.MarkFlagRequired` error behaviour on a standalone command.
No production code is modified; only test coverage increases.

<details>
<summary><strong>Key Changes</strong></summary>

• Created `internal/gen/gen_test.go` with 61 new lines of tests
• Added `TestNewCommandFlags` to validate flag presence, required-flag enforcement and safe execution paths
• Added `TestMarkFlagRequiredBehavior` to assert correct behaviour of `cobra.MarkFlagRequired` when the flag exists

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `internal/gen` (tests only)

</details>

---
*This summary was automatically generated by @propel-code-bot*