### PR TITLE
Add version subcommand to report gorm-cli build version

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,22 +24,19 @@ func main() {
 	}
 }
 
-func getVersion() string {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		if info.Main.Version != "" && info.Main.Version != "(devel)" {
-			return info.Main.Version
-		}
-	}
-
-	return "dev"
-}
-
 func versionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of gorm-cli",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("gorm-cli version %s\n", getVersion())
+			if info, ok := debug.ReadBuildInfo(); ok {
+				if info.Main.Version != "" && info.Main.Version != "(devel)" {
+					fmt.Printf("gorm-cli version %s\n", info.Main.Version)
+					return
+				}
+			}
+
+			fmt.Printf("gorm-cli version %s\n", "dev")
 		},
 	}
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds a version subcommand that prints the current CLI version. The version can be set at build time using -ldflags "-X main.Version=x.y.z" and defaults to v0.2.4. This helps users identify which version they have installed for troubleshooting and bug reports.
<!-- Summary by @propel-code-bot -->

---

**Add CLI `version` subcommand using Go build metadata**

Adds a new `version` subcommand to the CLI root command that reports the build version of `gorm-cli`. The command inspects `debug.ReadBuildInfo()` at runtime, printing `info.Main.Version` when populated and falling back to `dev` when the binary lacks module version metadata.

<details>
<summary><strong>Key Changes</strong></summary>

• Imported `runtime/debug` in `main.go` to access Go build metadata
• Registered the new `versionCmd()` with the root Cobra command alongside `gen.New()`
• Implemented `versionCmd()` to emit `gorm-cli version <version>` with a fallback to `dev` when `debug.ReadBuildInfo()` is unavailable or returns `(devel)`

</details>

<details>
<summary><strong>Affected Areas</strong></summary>

• `main.go`

</details>

---
*This summary was automatically generated by @propel-code-bot*